### PR TITLE
Revised error handling and simplified  message output options.

### DIFF
--- a/77-cloudant-cf.html
+++ b/77-cloudant-cf.html
@@ -88,10 +88,8 @@
     <div class="form-row">
         <label for="node-input-outputmsg"><i class="fa fa-wrench"></i>output msg</label>
         <select type="text" id="node-input-outputmsg" style="width:68%;">
-            <option value="none">none</option>
-            <option value="error">error</option>
-            <option value="success">success</option>
-            <option value="all">all</option>
+            <option value="no">no</option>
+            <option value="yes">yes</option>
         </select>
     <script>
         $("#node-input-operation").change(function() {
@@ -149,7 +147,7 @@
             service: { value:"", required:true },
             payonly: { value:false },
             operation: { value:"insert" },
-            outputmsg: { value:"none" }
+            outputmsg: { value:"no" }
         },
         inputs: 1,
         outputs: 0,
@@ -162,7 +160,7 @@
         oneditprepare: oneditprepare,
         oneditsave: function() {
             var oval = $("#node-input-outputmsg").val();
-            if (oval == "none") this.outputs = 0;
+            if (oval == "no") this.outputs = 0;
             else this.outputs = 1;
         }
     });
@@ -287,12 +285,18 @@
         </ul>
     </p>
     <p>
-        You can specify that an output message is generated - either always (all) or for success or error. 
-        In the event of an error the message output will be the original 
-        message with a dbError field showing the error. For successful inserts or updates, 
-        the message output will be the original message with the _id and _rev fields 
+        You can specify that an output message is generated for
+        successful inserts or updates. When enabled, the message
+        output will be the original <code>msg</code> with the _id and _rev fields 
         updated in either the message body or in the payload.
         The default setting is that no output message is generated.
+
+    </p>
+    <p>
+        Errors are returned via <code>node.error(err)</code> calls and can be 
+        caught by Catch nodes present on the same tab.
+        When a <code>msg</code> object is in scope it is returned via <code>node.error(err, msg)</code>.
+        Additional database error details are added to <code>msg.dbError</code>.
     </p>
     <p>
         Your document should avoid having top-level fields that start with
@@ -350,5 +354,11 @@
             <li>All letters in small caps</li>
             <li>The first character can't be <code>_</code></li>
         </ul>
+    </p>
+    <p>
+        Errors are returned via <code>node.error(err)</code> calls and can be 
+        caught by Catch nodes present on the same tab.
+        When a <code>msg</code> object is in scope it is returned via <code>node.error(err, msg)</code>.
+        Additional database error details are added to <code>msg.dbError</code>.
     </p>
 </script>

--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ in JSON format, it will be transformed before being stored.
 For **update** and **delete**, you must pass the `_id` and the `_rev`as part
 of the input `msg` object.
 
-For **insert** and **update**, you can specify that an output message is generated - either
-always (all) or for success or error. In the event of an error the message output will be the original
-message with a dbError field showing the error. For successful inserts or updates, the message output
-will be the original message with the _id and _rev fields updated in either the message body or in the payload.
+For **insert** and **update**, you can specify that an output message is generated.
+For successful inserts or updates, the message output will be the original message 
+with the _id and _rev fields updated in either the message body or in the payload.
 
 To **search** for a document you have two options: get a document directly by
 its `_id` or use an existing [search index](https://cloudant.com/for-developers/search/)
@@ -35,6 +34,10 @@ from the database. For both cases, the query should be passed in the
 
 When getting documents by id, the `payload` will be the desired `_id` value.
 For `search indexes`, the query should follow the format `indexName:value`.
+
+Errors are returned via node.error(err, msg) calls and can be caught by Catch nodes present
+on the same tab, msg objects are returned and available to the Catch nodes.
+Additional database error details are added to msg.dbError.
 
 Authors
 -------


### PR DESCRIPTION
Building on the really useful change to support output messages from CloudantOutNode, these mods (hopefully) simplify and standardize error handling.
Ensuring that the msg is returned on errors, allow flows to be built that can recover from race conditions / update contention issues.
Key changes:
Revised error handling to ensure all errors are raised via node.error(err, msg)
Revised message handling to ensure the original message is returned un-changed on errors.
Revised CloudantOutNode message output option simplifying to just yes/no, to return the msg, with errors returned via node.error().
updated README.md and 77-cloudant-cf.html doco to reflect changes.